### PR TITLE
Add support for explicit imports

### DIFF
--- a/src/main/lib/bundle/bundlers/bundler.ts
+++ b/src/main/lib/bundle/bundlers/bundler.ts
@@ -11,6 +11,11 @@ const readFileAsync = util.promisify(readFile);
 const writeFileAsync = util.promisify(writeFile);
 const unlinkAsync = util.promisify(unlink);
 
+/**
+ * A
+ */
+const ignorePaths: Set<string> = new Set;
+
 export abstract class Bundler {
   constructor(
     public rootNames: Bundler.RootName[] = []
@@ -38,13 +43,43 @@ export abstract class Bundler {
   @MemoizeProcedure
   static async *walkSource(filepath: string): AsyncIterableIterator<Bundler.RootName> {
     const $ = await Bundler.readSource(filepath);
+
+    for (const elem of $("wcm\\:ignore[path]").toArray()) {
+      const lookupPath = path.resolve(path.dirname(filepath), elem.attribs.path);
+      $(elem).remove();
+
+      if (!ignorePaths.has(lookupPath)) {
+        ignorePaths.add(lookupPath);
+      }
+    }
+
+    for (const elem of $("wcm\\:import[path]").toArray()) {
+      const lookupPath = path.resolve(path.dirname(filepath), elem.attribs.path);
+      $(elem).remove();
+
+      if (!ignorePaths.has(lookupPath)) {
+        yield [null, lookupPath];
+      }
+    }
   
     for (const elem of $('link[rel="import"]').toArray()) {
-      yield [$(elem), path.resolve(path.dirname(filepath), $(elem).attr("href"))];
+      const lookupPath = path.resolve(path.dirname(filepath), $(elem).attr("href"));
+
+      if (!ignorePaths.has(lookupPath)) {
+        yield [$(elem), lookupPath];
+      } else {
+        $(elem).remove();
+      }
     }
   
     for (const elem of $('script[src]').toArray()) {
-      yield [$(elem), path.resolve(path.dirname(filepath), $(elem).attr("src"))];
+      const lookupPath = path.resolve(path.dirname(filepath), $(elem).attr("src"));
+
+      if (!ignorePaths.has(lookupPath)) {
+        yield [$(elem), lookupPath];
+      } else {
+        $(elem).remove();
+      }
     }
   }
 
@@ -54,7 +89,7 @@ export abstract class Bundler {
       throw Error(`File extension is not .html: ${filepath}`);
     }
     
-    return load(await Bundler.readFile(filepath))
+    return load(await Bundler.readFile(filepath));
   }
 
   @MemoizeProcedure
@@ -63,7 +98,7 @@ export abstract class Bundler {
       throw Error(`Filepath is not absolute: ${filepath}`);
     }
 
-    return readFileAsync(filepath, "utf8")
+    return readFileAsync(filepath, "utf8");
   }
 
   static writeFile(filepath: string, contents: string): Promise<void> {
@@ -71,7 +106,7 @@ export abstract class Bundler {
       throw Error(`Filepath is not absolute: ${filepath}`);
     }
 
-    return writeFileAsync(filepath, contents, "utf8")
+    return writeFileAsync(filepath, contents, "utf8");
   }
 
   @MemoizeProcedure

--- a/src/main/lib/bundle/bundlers/bundler.ts
+++ b/src/main/lib/bundle/bundlers/bundler.ts
@@ -12,7 +12,7 @@ const writeFileAsync = util.promisify(writeFile);
 const unlinkAsync = util.promisify(unlink);
 
 /**
- * A
+ * A set of paths to ignore from the bundling process.
  */
 const ignorePaths: Set<string> = new Set;
 
@@ -115,7 +115,7 @@ export abstract class Bundler {
   }
 
   static async extractContentsFromStatic($: CheerioStatic): Promise<string> {
-    return $("head").html() as string + $("body").html() as string;
+    return ($("head").html() as string + $("body").html() as string).trim();
   }
 }
 

--- a/src/main/lib/bundle/index.ts
+++ b/src/main/lib/bundle/index.ts
@@ -150,7 +150,11 @@ export function walkProject(mode: "internal" | "external" | "*"): ConfigReader<B
   }
 }
 
-function flattenComponents(components: Record<string, string[]>): Array<[string, string]> {
+function flattenComponents(components: Record<string, string[]> | string[]): Array<[string, string]> {
+  if (Array.isArray(components)) {
+    components = { "": components };
+  }
+  
   return Object.entries(components).reduce((acc, [groupRoot, entries]) => {
     return acc.concat(entries.map((entry): [string, string] => ([groupRoot, entry])));
   }, [] as Array<[string, string]>);

--- a/src/main/lib/pack/index.ts
+++ b/src/main/lib/pack/index.ts
@@ -30,7 +30,8 @@ export function packComponent(filepath: string) {
 
     const bundleOutDir = config[0].get("bundleOutDir");
     const interceptSrc = config[1].get("interceptSrc");
-    const found: string[] = [];
+    
+    const found: Set<string> = new Set;
 
     let completed = 0;
     let pending = 0;
@@ -48,16 +49,16 @@ export function packComponent(filepath: string) {
     yield [completed, pending, "Finished"];
   });
 
-  async function *walkTargetFile(filepath: string, interceptSrc: string, found: string[]): AsyncIterableIterator<Bundler.RootName> {
+  async function *walkTargetFile(filepath: string, interceptSrc: string, found: Set<string>): AsyncIterableIterator<Bundler.RootName> {
     for await (let [ref, includePath] of Bundler.walkSource(filepath)) {
       if (includePath.startsWith(`/${interceptSrc}`)) {
         includePath = path.resolve(path.join(".", includePath));
       }
 
-      if (!found.includes(includePath)) {
-        found.push(includePath);
-      } else {
+      if (found.has(includePath)) {
         continue;
+      } else {
+        found.add(includePath);
       }
 
       if (includePath.endsWith(".html")) {


### PR DESCRIPTION
This commit adds the ability to define explicit imports in an HTML file
by using a "wcm:import" tag, and additionally ignore imports globally
through the use of an "wcm:ignore" tag.