### PR TITLE
Improve bootstrapping for legacy browsers

### DIFF
--- a/src/main/lib/browser/index.ts
+++ b/src/main/lib/browser/index.ts
@@ -42,7 +42,7 @@ export function createWorkerRegCode(): ConfigReader<BrowserConfig, string> {
       window.WCM = {
         bootstrap() {
           if (!('serviceWorker' in navigator && 'fetch' in window)) {
-            return ${config.get("enableLegacySupport") ? "Promise.resolve()" : "Promise.reject()"};
+            return ${config.get("enableLegacySupport") ? "Promise.reject()" : "throw Error('Browser not supported')"};
           }
 
           return navigator.serviceWorker.register('./wcm-impl.js')


### PR DESCRIPTION
The bootstrap function will now reject when in legacy mode, and throw an error if WCM can start.